### PR TITLE
fix: preserve quiz result across auth flow, fix feedback form

### DIFF
--- a/components/FeedbackWidget.tsx
+++ b/components/FeedbackWidget.tsx
@@ -1,48 +1,93 @@
 import { useState } from 'react';
 import { trackEvent } from '@/utils/analytics';
 
+type Status = 'idle' | 'sending' | 'success' | 'error';
+
 export default function FeedbackWidget() {
   const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('sending');
+
+    try {
+      const res = await fetch('https://formsubmit.co/ajax/9c1f086357e6fa897cd03359dd9712a6', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ message }),
+      });
+
+      if (res.ok) {
+        trackEvent('feedback_submit');
+        setStatus('success');
+        setMessage('');
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setStatus('idle');
+    setMessage('');
+  };
 
   return (
     <>
-      {/* Floating button */}
       <button
         onClick={() => setOpen(true)}
         className="fixed bottom-20 right-4 bg-blue-600 text-white px-4 py-2 rounded-full shadow-lg z-50 hover:bg-blue-700 transition sm:text-sm text-base"
       >
-      💬 Обратная связь
+        💬 Обратная связь
       </button>
 
       {open && (
         <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
           <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-md mx-4 relative">
             <button
-              onClick={() => setOpen(false)}
+              onClick={handleClose}
               className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-xl"
             >
               &times;
             </button>
             <h3 className="text-lg font-semibold mb-2 text-gray-800">Обратная связь</h3>
-            <form
-              action="https://formsubmit.co/el/vovabe"
-              method="POST"
-              onSubmit={() => trackEvent('feedback_submit')}
-            >
-              <input type="hidden" name="_captcha" value="false" />
-              <textarea
-                name="message"
-                required
-                placeholder="Напишите ваш отзыв..."
-                className="w-full h-32 border rounded p-2 mb-4 text-sm text-black placeholder-gray-500 bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-              ></textarea>
-              <button
-                type="submit"
-                className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition w-full text-sm"
-              >
-                Отправить
-              </button>
-            </form>
+
+            {status === 'success' ? (
+              <p className="text-green-600 text-sm text-center py-6">
+                Спасибо! Сообщение отправлено.
+              </p>
+            ) : (
+              <form onSubmit={handleSubmit}>
+                <textarea
+                  name="message"
+                  required
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Напишите ваш отзыв..."
+                  className="w-full h-32 border rounded p-2 mb-4 text-sm text-black placeholder-gray-500 bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+                {status === 'error' && (
+                  <p className="text-red-500 text-sm mb-2 text-center">
+                    Не удалось отправить. Попробуйте позже.
+                  </p>
+                )}
+                <button
+                  type="submit"
+                  disabled={status === 'sending'}
+                  className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition w-full text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {status === 'sending' ? 'Отправляем...' : 'Отправить'}
+                </button>
+              </form>
+            )}
           </div>
         </div>
       )}

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -8,10 +8,12 @@ export default function SignIn() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const [hasSavedQuiz, setHasSavedQuiz] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => setLoading(false), 200); // предотвращает серость из-за автозаполнения
+    setHasSavedQuiz(!!localStorage.getItem('quiz_result'));
     return () => clearTimeout(timer);
   }, []);
 
@@ -24,7 +26,12 @@ export default function SignIn() {
       setError(error.message);
     } else {
       trackEvent('sign_in_success');
-      router.push('/dashboard');
+      const savedScore = localStorage.getItem('quiz_result');
+      if (savedScore) {
+        router.push(`/result?score=${savedScore}`);
+      } else {
+        router.push('/dashboard');
+      }
     }
   };
 
@@ -40,6 +47,12 @@ export default function SignIn() {
     <main className="min-h-screen flex justify-center items-center bg-sky-100">
       <form onSubmit={handleLogin} className="bg-white p-6 rounded-lg shadow-md space-y-4 w-full max-w-md">
         <h1 className="text-xl font-bold text-center text-gray-800">Вход</h1>
+
+        {hasSavedQuiz && (
+          <p className="text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded p-3 text-center">
+            После подтверждения почты вернитесь на эту вкладку — здесь сохранится ваш результат.
+          </p>
+        )}
 
         {error && <p className="text-red-500 text-sm text-center">{error}</p>}
 

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -7,12 +7,11 @@ export default function SignUp() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [hasSavedQuiz, setHasSavedQuiz] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 200); // предотвратим race condition
-    return () => clearTimeout(timer);
+    setHasSavedQuiz(!!localStorage.getItem('quiz_result'));
   }, []);
 
   const handleSignup = async (e: React.FormEvent) => {
@@ -33,18 +32,10 @@ export default function SignUp() {
       setError(error.message);
     } else {
       trackEvent('sign_up_success');
-      alert('Письмо с подтверждением отправлено. Проверь почту и затем войди.');
+      alert('Письмо отправлено! После подтверждения вернитесь на эту вкладку — здесь сохранится ваш результат.');
       router.push('/auth/signin');
     }
   };
-
-  if (loading) {
-    return (
-      <main className="min-h-screen flex items-center justify-center bg-sky-100">
-        <p className="text-gray-500 text-center text-sm">Загрузка...</p>
-      </main>
-    );
-  }
 
   return (
     <main className="min-h-screen flex justify-center items-center bg-sky-100">
@@ -54,6 +45,12 @@ export default function SignUp() {
         <p className="text-sm text-gray-600 text-center">
           Введите email и пароль, затем подтвердите email по ссылке на почте. После этого вы сможете войти.
         </p>
+
+        {hasSavedQuiz && (
+          <p className="text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded p-3 text-center">
+            После подтверждения почты вернитесь на эту вкладку — здесь сохранится ваш результат.
+          </p>
+        )}
 
         {error && <p className="text-red-500 text-sm text-center">{error}</p>}
 

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -40,7 +40,7 @@ export default function ResultPage() {
 
   const handleSaveAndGoToDashboard = async () => {
     if (!session?.user) {
-      alert('Сначала войдите в аккаунт, чтобы сохранить результат');
+      localStorage.setItem('quiz_result', String(score));
       router.push('/auth/signin');
       return;
     }
@@ -59,6 +59,7 @@ export default function ResultPage() {
       console.error('Ошибка при сохранении:', error.message);
       alert('Не удалось сохранить результат. Попробуйте позже.');
     } else {
+      localStorage.removeItem('quiz_result');
       router.push('/dashboard');
     }
   };


### PR DESCRIPTION
- Save quiz_result to localStorage before redirecting to sign-in, restore score on /result after login
- Show contextual hint on signin/signup pages when quiz result is pending
- Fix signup page showing unnecessary loading state (caused perceived redirect bug)
- Switch FeedbackWidget from HTML form action to fetch AJAX (formsubmit.co), add success/error/sending states, fix redirect-on-submit UX issue